### PR TITLE
feat: メッセージリンクを展開する機能を追加

### DIFF
--- a/cmd/sparkle/main.go
+++ b/cmd/sparkle/main.go
@@ -43,6 +43,7 @@ func run(ctx context.Context) exitCode {
 	do.Provide(injector, di.NewLoggerInjector(logger))
 	do.Provide(injector, di.NewSessionInjector(token))
 	do.Provide(injector, handler.NewReadyHandler)
+	do.Provide(injector, handler.NewMessageLinkExpandHandler)
 	do.Provide(injector, bot.NewBot)
 
 	// health check

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -12,9 +12,10 @@ var _ do.Provider[*Bot] = NewBot
 var _ do.Healthcheckable = (*Bot)(nil)
 
 type Bot struct {
-	session *discordgo.Session
-	ready   handler.ReadyHandler
-	remover []func()
+	session   *discordgo.Session
+	ready     handler.ReadyHandler
+	msgExpand handler.MessageLinkExpandHandler
+	remover   []func()
 }
 
 // NewBot creates a new Bot instance.
@@ -35,10 +36,18 @@ func NewBot(i *do.Injector) (*Bot, error) {
 			Errorf("dependency resolution failed: %w", err)
 	}
 
+	msgExpand, err := do.Invoke[handler.MessageLinkExpandHandler](i)
+	if err != nil {
+		return nil, oops.
+			In("Bot").
+			Errorf("dependency resolution failed: %w", err)
+	}
+
 	return &Bot{
-		session: session,
-		ready:   ready,
-		remover: make([]func(), 0),
+		session:   session,
+		ready:     ready,
+		msgExpand: msgExpand,
+		remover:   make([]func(), 0),
 	}, nil
 }
 

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -54,6 +54,7 @@ func NewBot(i *do.Injector) (*Bot, error) {
 func (b *Bot) Start() error {
 	b.remover = append(b.remover,
 		b.session.AddHandler(b.ready.Ready),
+		b.session.AddHandler(b.msgExpand.Expand),
 	)
 	if err := b.session.Open(); err != nil {
 		return oops.

--- a/internal/bot/handler/message_link_expand.go
+++ b/internal/bot/handler/message_link_expand.go
@@ -1,0 +1,141 @@
+package handler
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/aqyuki/sparkle/pkg/logging"
+	"github.com/bwmarrin/discordgo"
+	"github.com/samber/do"
+	"go.uber.org/zap"
+)
+
+var _ MessageLinkExpandHandler = (*messageLinkExpandHandler)(nil)
+var _ do.Provider[MessageLinkExpandHandler] = NewMessageLinkExpandHandler
+
+type MessageLinkExpandHandler interface {
+	Expand(session *discordgo.Session, message *discordgo.MessageCreate)
+}
+
+type messageLinkExpandHandler struct {
+	logger *zap.SugaredLogger
+	rgx    *regexp.Regexp
+}
+
+func NewMessageLinkExpandHandler(i *do.Injector) (MessageLinkExpandHandler, error) {
+	logger, err := do.Invoke[*zap.SugaredLogger](i)
+	if err != nil {
+		logger = logging.DefaultLogger()
+		logger.Warn("dependency resolution failed for *zap.SugaredLogger and recovered with the default logger")
+	}
+
+	return &messageLinkExpandHandler{
+		logger: logger,
+		rgx:    regexp.MustCompile(`https://(?:ptb\.|canary\.)?discord(app)?\.com/channels/(\d+)/(\d+)/(\d+)`),
+	}, nil
+}
+
+func (h *messageLinkExpandHandler) Expand(session *discordgo.Session, message *discordgo.MessageCreate) {
+	if message.Author.Bot {
+		h.logger.Info("skip bot message")
+		return
+	}
+
+	links := h.extractLink(message.Content)
+	if len(links) == 0 {
+		h.logger.Info("no message link found")
+		return
+	}
+
+	// 荒らし対策で，リンクが複数ある場合は最初のリンクのみ展開する
+	link := links[0]
+	info, err := h.extractMessageInfo(link)
+	if err != nil {
+		h.logger.Errorf("failed to extract message info: %v", err)
+		return
+	}
+
+	// 違うギルドのメッセージは展開しない
+	if info.guild != message.GuildID {
+		h.logger.Info("skip message from different guild")
+		return
+	}
+
+	// 対象のメッセージが投稿されたチャンネルがNSFWの場合は展開しない
+	channel, err := session.Channel(info.channel)
+	if err != nil {
+		h.logger.Errorf("failed to get channel: %v", err)
+		return
+	}
+	if channel.NSFW {
+		h.logger.Info("skip NSFW channel")
+		return
+	}
+
+	// 対象メッセージを取得
+	msg, err := session.ChannelMessage(info.channel, info.message)
+	if err != nil {
+		h.logger.Errorf("failed to get message: %v", err)
+		return
+	}
+
+	var image *discordgo.MessageEmbedImage
+	if len(msg.Attachments) > 0 {
+		image = &discordgo.MessageEmbedImage{
+			URL: msg.Attachments[0].URL,
+		}
+	}
+
+	embed := &discordgo.MessageEmbed{
+		Image: image,
+		Author: &discordgo.MessageEmbedAuthor{
+			Name:    msg.Author.Username,
+			IconURL: msg.Author.AvatarURL("64"),
+		},
+		Color:       0x7fffff,
+		Description: msg.Content,
+		Timestamp:   msg.Timestamp.Format(time.RFC3339),
+		Footer: &discordgo.MessageEmbedFooter{
+			Text: channel.Name,
+		},
+	}
+
+	replyMsg := discordgo.MessageSend{
+		Embeds:    []*discordgo.MessageEmbed{embed},
+		Reference: message.Reference(),
+		AllowedMentions: &discordgo.MessageAllowedMentions{
+			RepliedUser: true,
+		},
+	}
+
+	if _, err := session.ChannelMessageSendComplex(message.ChannelID, &replyMsg); err != nil {
+		h.logger.Errorf("failed to send message: %v", err)
+		return
+	}
+	h.logger.Info("message link expanded")
+}
+
+func (h *messageLinkExpandHandler) extractLink(content string) []string {
+	return h.rgx.FindAllString(content, -1)
+}
+
+// extractMessageInfo extracts the channel ID and message ID from the message link.
+func (h *messageLinkExpandHandler) extractMessageInfo(link string) (info message, err error) {
+	segments := strings.Split(link, "/")
+	if len(segments) < 4 {
+		return message{}, errors.New("invalid message link")
+	}
+	return message{
+		guild:   segments[len(segments)-3],
+		channel: segments[len(segments)-2],
+		message: segments[len(segments)-1],
+	}, nil
+}
+
+type message struct {
+	guild   string
+	channel string
+	message string
+}

--- a/internal/bot/handler/message_link_expand_test.go
+++ b/internal/bot/handler/message_link_expand_test.go
@@ -1,0 +1,47 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/samber/do"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func TestNewMessageLinkExpandHandler(t *testing.T) {
+	type deps struct {
+		logger do.Provider[*zap.SugaredLogger]
+	}
+	tests := []struct {
+		name string
+		deps deps
+	}{
+		{
+			name: "success to create a new ready handler",
+			deps: deps{
+				logger: func(i *do.Injector) (*zap.SugaredLogger, error) {
+					return zap.NewExample().Sugar(), nil
+				},
+			},
+		},
+		{
+			name: "success to create a new ready handler with default logger",
+			deps: deps{
+				logger: func(i *do.Injector) (*zap.SugaredLogger, error) {
+					return nil, assert.AnError
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// init DI container
+			i := do.New()
+			do.Provide(i, tt.deps.logger)
+
+			actual, err := NewMessageLinkExpandHandler(i)
+			assert.NoError(t, err)
+			assert.NotNil(t, actual)
+		})
+	}
+}

--- a/internal/bot/handler/ready_test.go
+++ b/internal/bot/handler/ready_test.go
@@ -15,7 +15,6 @@ func TestNewReadyHandler(t *testing.T) {
 	tests := []struct {
 		name string
 		deps deps
-		want ReadyHandler
 	}{
 		{
 			name: "success to create a new ready handler",


### PR DESCRIPTION
## 対応Issue

## 対応内容・対応背景・妥協点

## やったこと
- メッセージ作成時，メッセージにメッセージへのリンクが含まれている場合Embedで展開する機能を追加

## やってないこと
- discordgoとの結合テスト

## UI before / after

## テスト
- コンストラクタのテストを追加　

## 補足
